### PR TITLE
Delete extraneous Jedis connection close

### DIFF
--- a/src/main/java/com/redislabs/redisgraph/RedisGraph.java
+++ b/src/main/java/com/redislabs/redisgraph/RedisGraph.java
@@ -92,7 +92,6 @@ public class RedisGraph implements Closeable {
 
         try (Jedis conn = getConnection()) {
             List<Object> rawResponsw = sendCompactCommand(conn, Command.QUERY, graphId, query).getObjectMultiBulkReply();
-            conn.close();
             return new ResultSetImpl(rawResponsw, graphCaches.get(graphId));
         }
         catch (Exception e){


### PR DESCRIPTION
From https://github.com/xetorthio/jedis/wiki/Getting-started :
```
/// Jedis implements Closeable. Hence, the jedis instance will be auto-closed after the last statement.
try (Jedis jedis = pool.getResource()) {
```
Removal of the unnecessary closure here seems to have resolved the concurrency crash. Let me know if this holds up!