### PR TITLE
Catch run-time and compile-time server exceptions

### DIFF
--- a/src/main/java/com/redislabs/redisgraph/impl/api/RedisGraph.java
+++ b/src/main/java/com/redislabs/redisgraph/impl/api/RedisGraph.java
@@ -67,6 +67,9 @@ public class RedisGraph extends AbstractRedisGraph implements RedisGraphContextG
             contextedRedisGraph.setRedisGraphCaches(caches);
             return contextedRedisGraph.sendQuery(graphId, preparedQuery);
         }
+        catch (Exception e) {
+            throw e;
+        }
     }
 
 

--- a/src/main/java/com/redislabs/redisgraph/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/redislabs/redisgraph/impl/resultset/ResultSetImpl.java
@@ -11,6 +11,7 @@ import com.redislabs.redisgraph.graph_entities.Node;
 import com.redislabs.redisgraph.graph_entities.Property;
 import com.redislabs.redisgraph.impl.graph_cache.GraphCache;
 import redis.clients.jedis.util.SafeEncoder;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,13 @@ public class ResultSetImpl implements ResultSet {
     public ResultSetImpl(List<Object> rawResponse, RedisGraph redisGraph, GraphCache cache) {
         this.redisGraph = redisGraph;
         this.cache = cache;
+
+        // If a run-time error occured, the last member of the rawResponse will be a JedisDataException.
+        if (rawResponse.get(rawResponse.size()-1) instanceof JedisDataException) {
+
+            throw (JedisDataException)rawResponse.get(rawResponse.size() - 1);
+        }
+
         if (rawResponse.size() != 3) {
 
             header = parseHeader(new ArrayList<>());

--- a/src/test/java/com/redislabs/redisgraph/RedisGraphAPITest.java
+++ b/src/test/java/com/redislabs/redisgraph/RedisGraphAPITest.java
@@ -881,4 +881,24 @@ public class RedisGraphAPITest {
         }
 
     }
+
+    @Test
+    public void testErrorReporting() {
+        Assert.assertNotNull(api.query("social", "CREATE (:person{mixed_prop: 'strval'}), (:person{mixed_prop: 50})"));
+
+        // Issue a query that causes a compile-time error
+        try {
+            api.query("social", "RETURN toUpper(5)");
+            Assert.fail(); // should be unreachable
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Type mismatch"));
+        }
+
+        // Issue a query that causes a run-time error
+        try {
+            api.query("social", "MATCH (p:person) RETURN toUpper(p.mixed_prop)");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Type mismatch"));
+        }
+    }
 }


### PR DESCRIPTION
This or similar will be necessary following the merge of https://github.com/RedisGraph/RedisGraph/pull/613

Compile-time errors are received by the client `sendQuery` logic as `JedisDataException`s, while for run-time errors, the last top-level member of the response will be a `JedisDataException`. 

I believe there may be an issue with premature thread closures here:
https://github.com/RedisGraph/JRedisGraph/blob/master/src/main/java/com/redislabs/redisgraph/impl/api/ContextedRedisGraph.java#L54
I think it would be preferable to not close the connection, at least for `JedisDataException` failures.
Let me know your thoughts!