### PR TITLE
missing parameter is now runtime error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	
 	<groupId>com.redislabs</groupId>
 	<artifactId>jredisgraph</artifactId>
-	<version>2.0.2-SNAPSHOT</version>
+	<version>2.0.3-SNAPSHOT</version>
 	
 	<name>JRedisGraph</name>
 	<description>Official client for Redis-Graph</description>

--- a/src/test/java/com/redislabs/redisgraph/exceptions/JRedisGraphErrorTest.java
+++ b/src/test/java/com/redislabs/redisgraph/exceptions/JRedisGraphErrorTest.java
@@ -90,14 +90,14 @@ public class JRedisGraphErrorTest {
 
     @Test
     public void testMissingParametersSyntaxErrorReporting(){
-        exceptionRule.expect(JRedisGraphCompileTimeException.class);
+        exceptionRule.expect(JRedisGraphRunTimeException.class);
         exceptionRule.expectMessage("Missing parameters");
         api.query("social","RETURN $param");
     }
 
     @Test
     public void testMissingParametersSyntaxErrorReporting2(){
-        exceptionRule.expect(JRedisGraphCompileTimeException.class);
+        exceptionRule.expect(JRedisGraphRunTimeException.class);
         exceptionRule.expectMessage("Missing parameters");
         api.query("social","RETURN $param", new HashMap<>());
     }


### PR DESCRIPTION
This PR brings JRedisGraph to comply with the changes in RedisGraph where missing parameters is a runtime exception

update version to 2.0.3 to comply with RedisGraph 2.0.8