### PR TITLE
recreate an existing index should report 0 indices added

### DIFF
--- a/src/test/java/com/redislabs/redisgraph/RedisGraphAPITest.java
+++ b/src/test/java/com/redislabs/redisgraph/RedisGraphAPITest.java
@@ -152,7 +152,6 @@ public class RedisGraphAPITest {
 
         ResultSet createExistingIndexResult = api.query("social", "CREATE INDEX ON :person(age)");
         Assert.assertFalse(createExistingIndexResult.hasNext());
-        Assert.assertNotNull(createExistingIndexResult.getStatistics().getStringValue(Label.INDICES_ADDED));
         Assert.assertEquals(0, createExistingIndexResult.getStatistics().indicesAdded());
 
         ResultSet deleteExistingIndexResult = api.query("social", "DROP INDEX ON :person(age)");


### PR DESCRIPTION
RedisGraph won't report `1 index created` when re-creating an existing index.