### PR TITLE
Remove Maven build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
+            <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
 		<dependency>


### PR DESCRIPTION
- Remove redundant dependency
- Use specific version instead of `RELEASE`; Maven has deprecated the keyword

Resolves #113 