### PR TITLE
Cannot test params on empty graph anymore

### DIFF
--- a/src/test/java/com/redislabs/redisgraph/RedisGraphAPITest.java
+++ b/src/test/java/com/redislabs/redisgraph/RedisGraphAPITest.java
@@ -721,50 +721,6 @@ public class RedisGraphAPITest {
     }
 
     @Test
-    public void testParameters() {
-        Object[] parameters = { 1, 2.3, true, false, null, "str", 'a', "b", Arrays.asList(1, 2, 3),
-                new Integer[] { 1, 2, 3 } };
-        Object[] expected_anwsers = { 1L, 2.3, true, false, null, "str", "a", "b", Arrays.asList(1L, 2L, 3L),
-                new Long[] { 1L, 2L, 3L } };
-        Map<String, Object> params = new HashMap<>();
-        for (int i = 0; i < parameters.length; i++) {
-            Object param = parameters[i];
-            params.put("param", param);
-            ResultSet resultSet = client.query("social", "RETURN $param", params);
-            Assert.assertEquals(1, resultSet.size());
-            Record r = resultSet.next();
-            Object o = r.getValue(0);
-            Object expected = expected_anwsers[i];
-            if (i == parameters.length - 1) {
-                expected = Arrays.asList((Object[]) expected);
-            }
-            Assert.assertEquals(expected, o);
-        }
-    }
-
-    @Test
-    public void testParametersReadOnly() {
-        Object[] parameters = { 1, 2.3, true, false, null, "str", 'a', "b", Arrays.asList(1, 2, 3),
-                new Integer[] { 1, 2, 3 } };
-        Object[] expected_anwsers = { 1L, 2.3, true, false, null, "str", "a", "b", Arrays.asList(1L, 2L, 3L),
-                new Long[] { 1L, 2L, 3L } };
-        Map<String, Object> params = new HashMap<>();
-        for (int i = 0; i < parameters.length; i++) {
-            Object param = parameters[i];
-            params.put("param", param);
-            ResultSet resultSetRo = client.readOnlyQuery("social", "RETURN $param", params);
-            Assert.assertEquals(1, resultSetRo.size());
-            Record rRo = resultSetRo.next();
-            Object oRo = rRo.getValue(0);
-            Object expected = expected_anwsers[i];
-            if (i == parameters.length - 1) {
-                expected = Arrays.asList((Object[]) expected);
-            }
-            Assert.assertEquals(expected, oRo);
-        }
-    }
-
-    @Test
     public void testNullGraphEntities() {
         // Create two nodes connected by a single outgoing edge.
         Assert.assertNotNull(client.query("social", "CREATE (:L)-[:E]->(:L2)"));


### PR DESCRIPTION
Note: We have many other tests of params, in non-empty graph. So removing the tests won't hurt testing procedures. If you could check the Codecov report, there's no change.