### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.redislabs/jredisgraph/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.redislabs/jredisgraph)
 [![Javadocs](https://www.javadoc.io/badge/com.redislabs/jredisgraph.svg)](https://www.javadoc.io/doc/com.redislabs/jredisgraph)
 [![Codecov](https://codecov.io/gh/RedisGraph/JRedisGraph/branch/master/graph/badge.svg)](https://codecov.io/gh/RedisGraph/JRedisGraph)
-[![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/RedisGraph/JRedisGraph.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RedisGraph/JRedisGraph/context:java)
 [![Known Vulnerabilities](https://snyk.io/test/github/RedisGraph/JRedisGraph/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/RedisGraph/JRedisGraph?targetFile=pom.xml)
 
 # JRedisGraph
@@ -70,7 +69,7 @@ public class RedisGraphExample {
         Map<String, Object> params = new HashMap<>();
         params.put("age", 30);
         params.put("name", "amit");
-       
+
         // send queries to a specific graph called "social"
         graph.query("social","CREATE (:person{name:'roi',age:32})");
         graph.query("social","CREATE (:person{name:$name,age:$age})", params);


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.